### PR TITLE
Fixing the encountered error

### DIFF
--- a/fe/src/App.js
+++ b/fe/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Routes, Route, useNavigate, Navigate } from 'react-router-dom';
 import './App.css';
 import HomePage from './HomePage';
@@ -29,7 +29,7 @@ function App() {
     navigate('/');
   };
 
-  const handleLogout = () => {
+  const handleLogout = useCallback(() => {
     setIsLoggedIn(false);
     setUsername('');
     localStorage.removeItem('token');
@@ -37,7 +37,7 @@ function App() {
     localStorage.removeItem('role');
     localStorage.removeItem('user_id');
     navigate('/');
-  };
+  }, [navigate]);
 
   return (
     <Routes>

--- a/fe/src/HomePage.js
+++ b/fe/src/HomePage.js
@@ -2,8 +2,9 @@ import React from "react";
 import logo from "./assets/images/LOGO_CVAOJ.png";
 import { useNavigate } from "react-router-dom";
 
-export default function HomePage({ onLogin, onRegister, isLoggedIn, username, onLogout, onViewProblems}) {
+export default function HomePage({ onLogin, onRegister, isLoggedIn, username, onLogout, onViewProblems }) {
     const navigate = useNavigate();
+    
     return (
         <div className="homepage">
             <nav className="navbar">


### PR DESCRIPTION
Add `useCallback` to `handleLogout` to fix "onLogout is not defined" error.

The error likely stemmed from `handleLogout` not maintaining a stable reference across re-renders, or hot reload issues. `useCallback` ensures the function is memoized, preventing unexpected re-definitions and ensuring it's always available when passed as a prop.

---
<a href="https://cursor.com/background-agent?bcId=bc-49f504ea-37d4-452f-b596-2615f56e3958">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49f504ea-37d4-452f-b596-2615f56e3958">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

